### PR TITLE
Added support for stopping multiple services at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Editor files
 *.code-workspace
+.idea
 
 # Build / Dependencies
 dist

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -3,3 +3,4 @@ export { clone } from "./clone";
 export { setup } from "./setup";
 export { run } from "./run";
 export { restart } from "./restart";
+export { stop } from "./stop";

--- a/src/tasks/stop.ts
+++ b/src/tasks/stop.ts
@@ -1,0 +1,40 @@
+import { prompts } from "lib/prompts";
+import { runTask } from "lib/exec";
+import { TaskNames } from "types";
+import { getAvailableServicesByTask } from "lib/service";
+import chalk from "chalk";
+
+export const stop = async (serviceId?: string) => {
+    if (serviceId) {
+        return runTask(serviceId, TaskNames.STOP);
+    }
+
+    const services = await getAvailableServicesByTask(TaskNames.STOP);
+
+    const questions = [
+        {
+            type: "multiselect",
+            name: "service",
+            message: "Which services do you want to stop?",
+            choices: services.map((service) => {
+                return {
+                    title: service.name,
+                    value: service.repo
+                };
+            }),
+            instructions: false,
+            hint: "- Space to select. Return to submit",
+        },
+    ];
+
+    const responses = await prompts(questions as any);
+
+    if (responses.__cancelled__) {
+        return console.log(chalk`
+    I'll be here waiting for the time you actually need to stop something :)`);
+    }
+
+    responses.service.forEach(async (service) => {
+        runTask(service, TaskNames.STOP);
+    });
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export enum TaskNames {
     RUN = "run",
     SETUP = "setup",
     CLONE = "clone",
+    STOP = "stop"
 }
 
 export type Service = {


### PR DESCRIPTION
**Why?**
In cases where the developer needs to work with a series of services (from now on **STACK**), results very inconvenient to stop one service at a time.

**How?**
Simple by just typing `aww stop`, a multiple-select list will be prompted allowing the user to choose multiple services to stop.
It's worth to mention that this also supports stop one specific service by just running `aww stop [service]`.